### PR TITLE
docs: add a datetime field in the Transaction table

### DIFF
--- a/docs/diagrams/erd.puml
+++ b/docs/diagrams/erd.puml
@@ -81,6 +81,7 @@ entity "Transaction" as transaction {
   *bankAccountNumber: text
   *bankAccountName: text
   *amount: number
+  *datetime: datetime
   *method: text
   *status : text
 }


### PR DESCRIPTION
because the confirmation datetime does not necessarily
equal to the payment datetime
