### PR TITLE
fix: correct typo in getFirstActiveSubscriptionByUserId

### DIFF
--- a/app/models/subscription.ts
+++ b/app/models/subscription.ts
@@ -60,7 +60,7 @@ export async function deactivateSubscription(
   )
 }
 
-export async function getFirstActiveSubcriptionByUserId(userId: string) {
+export async function getFirstActiveSubscriptionByUserId(userId: string) {
   return await db.subscription.findFirst({
     where: {
       userId,

--- a/app/routes/dashboard._index.tsx
+++ b/app/routes/dashboard._index.tsx
@@ -2,7 +2,7 @@ import type { LoaderFunction } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 import { Pricing } from '~/components/sections/pricing'
 import { SUBSCRIPTION_STATUS } from '~/models/enum'
-import { getFirstActiveSubcriptionByUserId } from '~/models/subscription'
+import { getFirstActiveSubscriptionByUserId } from '~/models/subscription'
 import { requireUser } from '~/services/auth.server'
 import { Handle } from '~/utils/types'
 import { SingleColumnLayout } from '~/components/single-column-layout'
@@ -13,7 +13,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   const { id } = await requireUser(request)
 
   // Get the subscription data from user where status is active
-  const subscription = await getFirstActiveSubcriptionByUserId(id)
+  const subscription = await getFirstActiveSubscriptionByUserId(id)
   return { isSubscribed: subscription?.status === SUBSCRIPTION_STATUS.ACTIVE }
 }
 


### PR DESCRIPTION
## Summary

The exported function `getFirstActiveSubcriptionByUserId` in `app/models/subscription.ts` had a missing `s` in 'Subscription'. Both the definition and its sole call site (`dashboard._index.tsx`) used the same typo consistently, so it worked — but the name didn't match the naming convention used by similar functions like `getFirstTransaction` and `getFirstCourse`.

## Changes

- Rename `getFirstActiveSubcriptionByUserId` → `getFirstActiveSubscriptionByUserId` in `subscription.ts`
- Update the import and call site in `dashboard._index.tsx`

No logic changes.