### PR TITLE
fix: correct field error labels in purchase confirm action

### DIFF
--- a/app/routes/dashboard.purchase.confirm.tsx
+++ b/app/routes/dashboard.purchase.confirm.tsx
@@ -75,9 +75,9 @@ export const action: ActionFunction = async ({ request }) => {
   }
 
   const fieldErrors = {
-    bankName: validateRequired('Nomor WhatsApp', bankName),
-    bankAccountNumber: validateRequired('Nama Bank', bankAccountNumber),
-    bankAccountName: validateRequired('Nomor Rekening', bankAccountName),
+    bankName: validateRequired('Nama Bank', bankName),
+    bankAccountNumber: validateRequired('Nomor Rekening', bankAccountNumber),
+    bankAccountName: validateRequired('Nama Pemilik Rekening', bankAccountName),
     amount: validateRequired('Nominal', amount),
   }
 


### PR DESCRIPTION
## Summary

The `validateRequired()` calls in the `dashboard.purchase.confirm` action had wrong label strings — each field was labelled with the **previous** field's name. This caused confusing validation error messages like `"Nomor WhatsApp wajib diisi"` when the Bank Name field was left empty.

### Before (wrong labels)

```typescript
const fieldErrors = {
  bankName:          validateRequired('Nomor WhatsApp', bankName),
  bankAccountNumber: validateRequired('Nama Bank', bankAccountNumber),
  bankAccountName:   validateRequired('Nomor Rekening', bankAccountName),
  amount:            validateRequired('Nominal', amount),
}
```

### After (matching form field labels)

```typescript
const fieldErrors = {
  bankName:          validateRequired('Nama Bank', bankName),
  bankAccountNumber: validateRequired('Nomor Rekening', bankAccountNumber),
  bankAccountName:   validateRequired('Nama Pemilik Rekening', bankAccountName),
  amount:            validateRequired('Nominal', amount),
}
```

Labels now match the corresponding `<Field label="..."\>` props in the form component.

## Testing

- ✅ All 116 unit tests pass
- ✅ TypeScript check passes (tsc --noEmit)
- ✅ ESLint + Prettier clean