### PR TITLE
chore: add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ bv-pages/
 
 # Local backup files
 prisma/backups/
+.envrc


### PR DESCRIPTION
Adds `.envrc` to `.gitignore` to prevent accidentally committing direnv environment files.

Also restores deleted `.beads/` files (unstaged deletions, not committed).