### PR TITLE
chore(lint): enforce tailwind design tokens

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,7 @@
     "ecmaVersion": 2021,
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint", "jsx-a11y"],
+  "plugins": ["react", "@typescript-eslint", "jsx-a11y", "tailwindcss"],
   "rules": {
     "import/extensions": [
       "warn",
@@ -42,7 +42,8 @@
     "import/no-unresolved": [2, { "commonjs": true, "amd": true }],
     "import/no-extraneous-dependencies": 2,
     "import/order": "error",
-    "react/react-in-jsx-scope": ["off"]
+    "react/react-in-jsx-scope": ["off"],
+    "tailwindcss/no-arbitrary-value": "error"
   },
   "settings": {
     "import/resolver": {
@@ -52,6 +53,9 @@
     },
     "react": {
       "version": "detect"
+    },
+    "tailwindcss": {
+      "config": "tailwind.config.js"
     }
   },
   "overrides": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "eslint-plugin-jsx-a11y": "6.5.1",
         "eslint-plugin-playwright": "2.4.0",
         "eslint-plugin-react": "7.27.1",
+        "eslint-plugin-tailwindcss": "^3.5.2",
         "eslint-plugin-yml": "0.12.0",
         "husky": "7.0.4",
         "is-ci-cli": "2.2.0",
@@ -7001,6 +7002,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-tailwindcss": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.5.2.tgz",
+      "integrity": "sha512-CW/Whm8KIC/8Pe68Q0YD9EmFa34r+Z3lkjAIj7vsKEg9ZvDVSOCJkerqePPkaK9ilRxpuGok0TCqWu1OfxE6Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.5",
+        "postcss": "^8.4.4",
+        "tailwindcss": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
     "node_modules/eslint-plugin-yml": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-0.12.0.tgz",
@@ -12429,6 +12445,32 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
     "node_modules/postcss-load-config": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
@@ -12476,6 +12518,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/postcss-modules": {
@@ -14476,32 +14528,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/postcss-js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
-      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "camelcase-css": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >= 16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.21"
       }
     },
     "node_modules/tailwindcss/node_modules/postcss-load-config": {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-playwright": "2.4.0",
     "eslint-plugin-react": "7.27.1",
+    "eslint-plugin-tailwindcss": "^3.5.2",
     "eslint-plugin-yml": "0.12.0",
     "husky": "7.0.4",
     "is-ci-cli": "2.2.0",


### PR DESCRIPTION
## Summary
- add `eslint-plugin-tailwindcss` pinned to a version compatible with the repo's current ESLint and Tailwind setup
- enable the Tailwind arbitrary value lint rule and point it at the local Tailwind config
- verify pre-commit enforcement through `lint-staged` so arbitrary classes like `bg-[#fff]` are rejected

## Verification
- `npm run lint`
- `npm test`
- `printf 'export function Demo(){return <div className="bg-[#fff] p-4" />}\n' | npx eslint --stdin --stdin-filename app/__tailwind-smoke.tsx`
- `npx lint-staged` with a temporary staged TSX file containing `bg-[#fff]`, confirmed failure from `tailwindcss/no-arbitrary-value`
