### PR TITLE
chore: add .npmrc with supply chain protection

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Supply chain protection
+# - save-exact: pin to exact versions instead of semver ranges
+# - min-release-age: quarantine newly published packages for 7 days
+#   (blocks typosquatting & fast-publish supply chain attacks like axios@1.14.1)
+save-exact=true
+min-release-age=7


### PR DESCRIPTION
## What

Adds `.npmrc` with supply chain protection settings:

- **`save-exact=true`** — pin exact versions instead of semver ranges (`^x.y.z`)
- **`min-release-age=7`** — quarantine newly published packages for 7 days

## Why

In response to the [axios supply chain attack](https://socket.dev/blog/axios-npm-package-compromised) (2026-03-31), where a compromised `axios@1.14.1` pulled in malicious `plain-crypto-js@4.2.1` published minutes before.

## Note

npm 11 shows a warning about `min-release-age` being unknown — this config may not be enforced until npm 12. A separate migration to pnpm is tracked in #242, which has full support for this feature (`minimum-release-age` in minutes).

## Impact

- `save-exact` works immediately
- `min-release-age` will take effect once npm fully supports it (or after pnpm migration)
- Existing lockfile is unaffected