### PR TITLE
chore: add .npmrc with supply chain protection

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Supply chain protection
+# - save-exact: pin to exact versions instead of semver ranges
+# - min-release-age: quarantine newly published packages for 7 days
+#   (blocks typosquatting & fast-publish supply chain attacks like axios@1.14.1)
+save-exact=true
+min-release-age=7


### PR DESCRIPTION
## Summary

Adds `.npmrc` with supply chain protection settings:

- **save-exact=true** — pins dependencies to exact versions instead of semver ranges, preventing unexpected updates
- **min-release-age=7** — quarantines newly published packages for 7 days, blocking typosquatting and fast-publish supply chain attacks (like the axios@1.14.1 incident)

## Test Plan

- Verified `npm install` still works with the new settings
- No functional changes to application code