### PR TITLE
Add Destructive Command Guard workflow

### DIFF
--- a/.github/workflows/destructive-command-guard.yml
+++ b/.github/workflows/destructive-command-guard.yml
@@ -15,9 +15,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Destructive Command Guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="v0.4.5"
+          platform="x86_64-unknown-linux-gnu"
+          install_dir="$RUNNER_TEMP/dcg"
+          mkdir -p "$install_dir"
+          curl --fail --location --silent --show-error \
+            "https://github.com/Dicklesworthstone/destructive_command_guard/releases/download/${version}/dcg-${platform}.tar.xz" \
+            --output "$install_dir/dcg.tar.xz"
+          tar -xJf "$install_dir/dcg.tar.xz" -C "$install_dir"
+          chmod +x "$install_dir/dcg"
+          echo "$install_dir" >> "$GITHUB_PATH"
+
       - name: Run Destructive Command Guard
-        uses: Dicklesworthstone/destructive_command_guard/action@v0.4.5
-        with:
-          paths: .
-          fail-on: error
-          format: pretty
+        shell: bash
+        run: dcg scan --paths . --fail-on error --format pretty

--- a/.github/workflows/destructive-command-guard.yml
+++ b/.github/workflows/destructive-command-guard.yml
@@ -1,0 +1,23 @@
+name: Destructive Command Guard
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan destructive commands
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Destructive Command Guard
+        uses: Dicklesworthstone/destructive_command_guard/action@v0
+        with:
+          paths: .
+          fail-on: error
+          format: pretty

--- a/.github/workflows/destructive-command-guard.yml
+++ b/.github/workflows/destructive-command-guard.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Destructive Command Guard
-        uses: Dicklesworthstone/destructive_command_guard/action@v0
+        uses: Dicklesworthstone/destructive_command_guard/action@v0.4.5
         with:
           paths: .
           fail-on: error


### PR DESCRIPTION
## Summary
- Add a conservative Destructive Command Guard workflow for repository-wide scan coverage.
- Pin DCG to v0.4.5 and install the Linux binary directly because the published composite action tag/installer currently does not resolve successfully on GitHub Actions.
- Keep permissions read-only and fail only on error-severity findings.

## Validation
- YAML parsed with Ruby YAML loader.
- `git diff --check` passed.
- GitHub Actions DCG job is now running from the direct binary installer.

## Current check result
- DCG check passes on the PR branch.