### PR TITLE
fix(email): disable Mailgun delivery on staging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ DATABASE_URL="file:./dev.db"
 MAILGUN_SENDING_KEY=key-some-mailgun-key
 MAILGUN_DOMAIN=some.domain.com
 EMAIL_FROM=Rumah Berbagi <admin@rumahberbagi.com>
+MAGIC_LINK_EMAIL_DELIVERY=mailgun
 
 # Feature: authentication
 # Mocked: Unnecessary (any value can be used)

--- a/app/services/__tests__/email.server.test.ts
+++ b/app/services/__tests__/email.server.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { User } from '@prisma/client'
 import { sendEmail } from '../email.server'
 import * as emailProvider from '~/services/email-provider.server'
@@ -6,21 +6,39 @@ import { userBuilder } from '~/models/__mocks__/user'
 
 describe('sendEmail', () => {
   const user = userBuilder() as User
+  const magicLink = 'http://localhost:3000/magic'
+
+  function resetEmailEnv() {
+    delete process.env.MAGIC_LINK_EMAIL_DELIVERY
+    delete process.env.RUNNING_E2E
+    delete process.env.STAGING_ENVIRONMENT
+  }
+
+  function sendMagicLink() {
+    return sendEmail({
+      emailAddress: user.email,
+      magicLink,
+      user,
+      domainUrl: 'https://localhost:3000/',
+      form: new FormData(),
+    })
+  }
 
   beforeEach(() => {
+    resetEmailEnv()
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    resetEmailEnv()
+    vi.unstubAllEnvs()
     vi.restoreAllMocks()
   })
 
   it('call emailProvider.sendEmail method', async () => {
     const spy = vi.spyOn(emailProvider, 'sendEmail')
 
-    await sendEmail({
-      emailAddress: user.email,
-      magicLink: 'http://localhost:3000/magic',
-      user,
-      domainUrl: 'https://localhost:3000/',
-      form: new FormData(),
-    })
+    await sendMagicLink()
 
     expect(spy).toHaveBeenCalledOnce()
     expect(spy).toHaveBeenCalledWith(
@@ -31,5 +49,53 @@ describe('sendEmail', () => {
         html: expect.stringContaining('localhost:3000/magic'),
       })
     )
+  })
+
+  it('logs the magic link without calling emailProvider when delivery is log', async () => {
+    process.env.MAGIC_LINK_EMAIL_DELIVERY = 'log'
+    const sendSpy = vi.spyOn(emailProvider, 'sendEmail')
+    const infoSpy = vi
+      .spyOn(console, 'info')
+      .mockImplementation(() => undefined)
+
+    await sendMagicLink()
+
+    expect(sendSpy).not.toHaveBeenCalled()
+    expect(infoSpy).toHaveBeenCalledWith(
+      '🔶 Magic link email delivery disabled:',
+      magicLink
+    )
+  })
+
+  it('throws when the delivery mode is unsupported', async () => {
+    process.env.MAGIC_LINK_EMAIL_DELIVERY = 'noop'
+    const sendSpy = vi.spyOn(emailProvider, 'sendEmail')
+
+    await expect(sendMagicLink()).rejects.toThrow(
+      'Unsupported MAGIC_LINK_EMAIL_DELIVERY: noop'
+    )
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws when log delivery is enabled in non-staging production', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    process.env.MAGIC_LINK_EMAIL_DELIVERY = 'log'
+    const sendSpy = vi.spyOn(emailProvider, 'sendEmail')
+
+    await expect(sendMagicLink()).rejects.toThrow(
+      'MAGIC_LINK_EMAIL_DELIVERY=log is only allowed in staging'
+    )
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+
+  it('throws when staging is configured to send through Mailgun', async () => {
+    process.env.STAGING_ENVIRONMENT = 'true'
+    process.env.MAGIC_LINK_EMAIL_DELIVERY = 'mailgun'
+    const sendSpy = vi.spyOn(emailProvider, 'sendEmail')
+
+    await expect(sendMagicLink()).rejects.toThrow(
+      'Staging requires MAGIC_LINK_EMAIL_DELIVERY=log'
+    )
+    expect(sendSpy).not.toHaveBeenCalled()
   })
 })

--- a/app/services/email.server.tsx
+++ b/app/services/email.server.tsx
@@ -10,6 +10,28 @@ if (process.env.EMAIL_FROM) {
   emailFrom = process.env.EMAIL_FROM
 }
 
+function getMagicLinkEmailDelivery() {
+  const delivery = process.env.MAGIC_LINK_EMAIL_DELIVERY ?? 'mailgun'
+
+  if (delivery !== 'mailgun' && delivery !== 'log') {
+    throw new Error(`Unsupported MAGIC_LINK_EMAIL_DELIVERY: ${delivery}`)
+  }
+
+  if (process.env.STAGING_ENVIRONMENT === 'true' && delivery !== 'log') {
+    throw new Error('Staging requires MAGIC_LINK_EMAIL_DELIVERY=log')
+  }
+
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.STAGING_ENVIRONMENT !== 'true' &&
+    delivery === 'log'
+  ) {
+    throw new Error('MAGIC_LINK_EMAIL_DELIVERY=log is only allowed in staging')
+  }
+
+  return delivery
+}
+
 export const sendEmail: SendEmailFunction<User> = async (options) => {
   const subject = 'Link login untuk Kelas Rumah Berbagi'
   const siteHost = new URL(options.magicLink).host
@@ -52,6 +74,14 @@ export const sendEmail: SendEmailFunction<User> = async (options) => {
       JSON.stringify({ magicLink: options.magicLink }, null, 2)
     )
     console.info('🔶 E2E: Captured magic link:', options.magicLink)
+    return
+  }
+
+  // In staging, allow operators to inspect magic links without sending Mailgun
+  // messages. This must be enabled explicitly so production behavior remains
+  // unchanged.
+  if (getMagicLinkEmailDelivery() === 'log') {
+    console.info('🔶 Magic link email delivery disabled:', options.magicLink)
     return
   }
 

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -41,6 +41,7 @@ env:
     DATABASE_URL: file:/app/prisma/staging.db
     STAGING_ENVIRONMENT: "true"
     EMAIL_FROM: Rumah Berbagi Staging <staging@rumahberbagi.com>
+    MAGIC_LINK_EMAIL_DELIVERY: log
   # Secret environment variables (loaded from .kamal/secrets)
   secret:
     - SESSION_SECRET


### PR DESCRIPTION
Closes #255

## Description

Adds an explicit `MAGIC_LINK_EMAIL_DELIVERY` mode for magic-link emails:

- `mailgun` / unset keeps the existing Mailgun send path.
- `log` logs the magic link and returns without calling Mailgun.
- staging deploy config sets `MAGIC_LINK_EMAIL_DELIVERY: log` so staging login links can be inspected from logs without consuming Mailgun quota.
- production deploy config remains unchanged.

Safety hardening after review:

- unsupported delivery modes throw instead of falling through to Mailgun;
- staging fails closed unless configured with `MAGIC_LINK_EMAIL_DELIVERY=log`;
- non-staging production rejects `MAGIC_LINK_EMAIL_DELIVERY=log` so production cannot silently stop sending if the variable leaks.

## Current Tasks

- [x] Add explicit magic-link delivery mode
- [x] Configure staging to log/no-op Mailgun delivery
- [x] Preserve production Mailgun behavior
- [x] Add focused tests for send, no-send, and misconfiguration paths

## Verification

- [x] `npm test -- app/services/__tests__/email.server.test.ts`
- [x] `npm run type-check`
- [x] `npm run lint` — passes with existing Playwright warnings only

## E2E evidence

Not run: this is a server-side email delivery/config change with focused unit coverage. No live staging deployment or VPS config changes were made.
