### PR TITLE
Require login nonce for magic-link requests

### DIFF
--- a/app/routes/__tests__/login.test.tsx
+++ b/app/routes/__tests__/login.test.tsx
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { action, loader } from '../login'
+import { auth } from '~/services/auth.server'
+import * as emailProvider from '~/services/email-provider.server'
+
+vi.mock('~/services/auth.server', () => ({
+  auth: {
+    authenticate: vi.fn(),
+    isAuthenticated: vi.fn(),
+    sessionErrorKey: 'auth:error',
+  },
+}))
+
+function getSetCookie(response: Response) {
+  const cookie = response.headers.get('Set-Cookie')
+  if (!cookie) throw new Error('Expected Set-Cookie header')
+  return cookie
+}
+
+async function loadLogin() {
+  const response = (await loader({
+    request: new Request('http://localhost:3000/login?redirectTo=/dashboard'),
+    params: {},
+    context: {},
+  } as never)) as Response
+
+  const data = (await response.json()) as { loginNonce: string }
+
+  return {
+    cookie: getSetCookie(response),
+    nonce: data.loginNonce,
+  }
+}
+
+function postLogin({ cookie, nonce }: { cookie?: string; nonce?: string }) {
+  const body = new URLSearchParams({ email: 'user@rumahberbagi.test' })
+  if (nonce) body.set('loginNonce', nonce)
+
+  return action({
+    request: new Request('http://localhost:3000/login?redirectTo=/dashboard', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...(cookie ? { Cookie: cookie } : {}),
+      },
+      body,
+    }),
+    params: {},
+    context: {},
+  } as never)
+}
+
+describe('login route nonce', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(auth.isAuthenticated).mockResolvedValue(null as never)
+  })
+
+  it('blocks direct POSTs without a nonce before email authentication can send Mailgun email', async () => {
+    const sendEmail = vi.spyOn(emailProvider, 'sendEmail')
+
+    const response = (await postLogin({})) as Response
+
+    expect(response).toBeInstanceOf(Response)
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')).toBe(
+      '/login?redirectTo=%2Fdashboard'
+    )
+    expect(auth.authenticate).not.toHaveBeenCalled()
+    expect(sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('blocks POSTs with an invalid nonce before email authentication can send Mailgun email', async () => {
+    const sendEmail = vi.spyOn(emailProvider, 'sendEmail')
+    const { cookie } = await loadLogin()
+
+    const response = (await postLogin({
+      cookie,
+      nonce: 'not-the-session-nonce',
+    })) as Response
+
+    expect(response).toBeInstanceOf(Response)
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')).toBe(
+      '/login?redirectTo=%2Fdashboard'
+    )
+    expect(auth.authenticate).not.toHaveBeenCalled()
+    expect(sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('allows a browser POST with the session-backed nonce to request a magic link', async () => {
+    const { cookie, nonce } = await loadLogin()
+    vi.mocked(auth.authenticate).mockImplementation(
+      async (_strategy, request) => {
+        const body = await (request as Request).text()
+
+        expect(body).toContain('email=user%40rumahberbagi.test')
+        expect(body).toContain(`loginNonce=${nonce}`)
+
+        return null as never
+      }
+    )
+
+    await postLogin({ cookie, nonce })
+
+    expect(auth.authenticate).toHaveBeenCalledOnce()
+    expect(auth.authenticate).toHaveBeenCalledWith(
+      'email-link',
+      expect.any(Request),
+      {
+        successRedirect: '/login?redirectTo=%2Fdashboard',
+        failureRedirect: '/login?redirectTo=%2Fdashboard',
+      }
+    )
+  })
+})

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,10 +1,17 @@
 import type { ActionFunction, LoaderFunction } from '@remix-run/node'
-import { json } from '@remix-run/node'
+import { json, redirect } from '@remix-run/node'
 import { Form, useLoaderData, useNavigation } from '@remix-run/react'
 import { Alert, ErrorAlert } from '~/components/alerts'
 import { Button } from '~/components/form-elements'
 import { auth } from '~/services/auth.server'
 import { commitSession, getUserSession } from '~/services/session.server'
+
+const loginNonceSessionKey = 'login:nonce'
+const loginNonceFormKey = 'loginNonce'
+
+function createLoginNonce() {
+  return crypto.randomUUID()
+}
 
 export const loader: LoaderFunction = async ({ request }) => {
   const url = new URL(request.url)
@@ -18,14 +25,18 @@ export const loader: LoaderFunction = async ({ request }) => {
   const error = session.get(auth.sessionErrorKey) as
     | { message: string }
     | undefined
+  const loginNonce = createLoginNonce()
 
   session.set('redirectTo', redirectTo)
+  session.set(loginNonceSessionKey, loginNonce)
 
   return json(
     {
       user: session.get('user'),
       magicLinkSent: session.has('zain:magiclink'),
       error: error?.message,
+      redirectTo,
+      loginNonce,
     },
     {
       headers: {
@@ -38,22 +49,49 @@ export const loader: LoaderFunction = async ({ request }) => {
 export const action: ActionFunction = async ({ request }) => {
   const url = new URL(request.url)
   const redirectTo = url.searchParams.get('redirectTo') ?? '/dashboard'
+  const failureRedirect = `/login?redirectTo=${encodeURIComponent(redirectTo)}`
+  const session = await getUserSession(request)
+  const form = await request.clone().formData()
+  const submittedNonce = form.get(loginNonceFormKey)
+  const expectedNonce = session.get(loginNonceSessionKey)
+
+  if (
+    typeof submittedNonce !== 'string' ||
+    typeof expectedNonce !== 'string' ||
+    submittedNonce !== expectedNonce
+  ) {
+    return redirect(failureRedirect, {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    })
+  }
+
+  session.unset(loginNonceSessionKey)
+  const committedSession = await commitSession(session)
+  const verifiedRequestHeaders = new Headers(request.headers)
+  verifiedRequestHeaders.set('Cookie', committedSession.split(';', 1)[0])
+  const verifiedRequest = new Request(request, {
+    headers: verifiedRequestHeaders,
+  })
 
   // The success redirect is required in this action, this is where the user is
   // going to be redirected after the magic link is sent, note that here the
   // user is not yet authenticated, so you can't send it to a private page.
-  await auth.authenticate('email-link', request, {
-    successRedirect: `/login?redirectTo=${encodeURIComponent(redirectTo)}`,
+  await auth.authenticate('email-link', verifiedRequest, {
+    successRedirect: failureRedirect,
     // If this is not set, any error will be throw and the ErrorBoundary will be
     // rendered.
-    failureRedirect: `/login?redirectTo=${encodeURIComponent(redirectTo)}`,
+    failureRedirect,
   })
 }
 
 export default function Login() {
-  const { magicLinkSent, error } = useLoaderData<{
+  const { magicLinkSent, error, redirectTo, loginNonce } = useLoaderData<{
     magicLinkSent: boolean
     error?: string
+    redirectTo: string
+    loginNonce: string
   }>()
   const { state } = useNavigation()
 
@@ -70,7 +108,16 @@ export default function Login() {
 
           <div className="mt-8">
             <div className="mt-6">
-              <Form action="/login" method="post" className="space-y-6">
+              <Form
+                action={`/login?redirectTo=${encodeURIComponent(redirectTo)}`}
+                method="post"
+                className="space-y-6"
+              >
+                <input
+                  type="hidden"
+                  name={loginNonceFormKey}
+                  value={loginNonce}
+                />
                 <div>
                   <label
                     htmlFor="email"


### PR DESCRIPTION
## Summary
- generate a session-backed login nonce on GET /login and render it as a hidden field
- reject missing/invalid nonce POSTs before calling the email-link authenticator
- consume the nonce on valid attempts while preserving redirectTo for normal browser login
- add route tests for missing, invalid, and valid nonce flows

Closes #256.

## Verification
- npx vitest run app/routes/__tests__/login.test.tsx
- npm run type-check
- npx eslint app/routes/login.tsx app/routes/__tests__/login.test.tsx
- npm test

## Notes
- This blocks blind direct POSTs to /login from triggering magic-link emails.
- Full anti-bot/rate limiting and strict concurrent replay prevention are out of scope for this issue.