### PR TITLE
fix(email): surface Mailgun delivery failures

### DIFF
--- a/app/services/__tests__/email.server.test.ts
+++ b/app/services/__tests__/email.server.test.ts
@@ -33,10 +33,13 @@ describe('sendEmail', () => {
     resetEmailEnv()
     vi.unstubAllEnvs()
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('call emailProvider.sendEmail method', async () => {
-    const spy = vi.spyOn(emailProvider, 'sendEmail')
+    const spy = vi
+      .spyOn(emailProvider, 'sendEmail')
+      .mockResolvedValue(new Response(null, { status: 200 }))
 
     await sendMagicLink()
 
@@ -97,5 +100,84 @@ describe('sendEmail', () => {
       'Staging requires MAGIC_LINK_EMAIL_DELIVERY=log'
     )
     expect(sendSpy).not.toHaveBeenCalled()
+  })
+
+  it('fails when the email provider fails', async () => {
+    vi.spyOn(emailProvider, 'sendEmail').mockRejectedValue(
+      new Error('Mailgun email delivery failed with 429')
+    )
+
+    await expect(sendMagicLink()).rejects.toThrow(
+      'Mailgun email delivery failed with 429'
+    )
+  })
+})
+
+describe('Mailgun email provider', () => {
+  const message = {
+    to: 'member@rumahberbagi.test',
+    from: 'Rumah Berbagi <admin@rumahberbagi.com>',
+    subject: 'Link login untuk Kelas Rumah Berbagi',
+    html: '<a href="https://kelas.rumahberbagi.test/magic?token=secret-token">Login</a>',
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns successful Mailgun responses', async () => {
+    const response = new Response('{"id":"message-id"}', { status: 200 })
+    const fetch = vi.fn().mockResolvedValue(response)
+    vi.stubGlobal('fetch', fetch)
+
+    await expect(emailProvider.sendEmail(message)).resolves.toBe(response)
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it('throws and logs sanitized context for failed Mailgun responses', async () => {
+    const apiKey = 'key-some-mailgun-key'
+    const encodedApiKey = Buffer.from(`api:${apiKey}`).toString('base64')
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            message:
+              'Monthly limit reached for member@rumahberbagi.test at https://kelas.rumahberbagi.test/magic?token=secret-token',
+          }),
+          {
+            status: 429,
+            statusText: 'Too Many Requests',
+            headers: { 'content-type': 'application/json' },
+          }
+        )
+      )
+    )
+
+    await expect(emailProvider.sendEmail(message)).rejects.toThrow(
+      'Mailgun email delivery failed with 429'
+    )
+
+    expect(consoleError).toHaveBeenCalledWith('Mailgun email delivery failed', {
+      response: {
+        status: 429,
+        statusText: 'Too Many Requests',
+        contentType: 'application/json',
+        body: expect.stringContaining('[redacted-email]'),
+      },
+    })
+    const logOutput = JSON.stringify(consoleError.mock.calls)
+    expect(logOutput).toContain('[redacted-url]')
+    expect(logOutput).not.toContain('member@rumahberbagi.test')
+    expect(logOutput).not.toContain('secret-token')
+    expect(logOutput).not.toContain(apiKey)
+    expect(logOutput).not.toContain(encodedApiKey)
   })
 })

--- a/app/services/__tests__/email.server.test.ts
+++ b/app/services/__tests__/email.server.test.ts
@@ -144,6 +144,7 @@ describe('Mailgun email provider', () => {
     const encodedRecipient = encodeURIComponent(message.to)
     const encodedMagicLinkToken = encodeURIComponent('token=secret-token')
     const echoedRequestBody = new URLSearchParams(message).toString()
+    const malformedPercentEncoding = 'bad%ZZ'
     const consoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)
@@ -154,6 +155,7 @@ describe('Mailgun email provider', () => {
           JSON.stringify({
             message: `Monthly limit reached for ${message.to} at https://kelas.rumahberbagi.test/magic?token=secret-token`,
             echoedRequestBody,
+            malformedPercentEncoding,
           }),
           {
             status: 429,

--- a/app/services/__tests__/email.server.test.ts
+++ b/app/services/__tests__/email.server.test.ts
@@ -141,6 +141,9 @@ describe('Mailgun email provider', () => {
   it('throws and logs sanitized context for failed Mailgun responses', async () => {
     const apiKey = 'key-some-mailgun-key'
     const encodedApiKey = Buffer.from(`api:${apiKey}`).toString('base64')
+    const encodedRecipient = encodeURIComponent(message.to)
+    const encodedMagicLinkToken = encodeURIComponent('token=secret-token')
+    const echoedRequestBody = new URLSearchParams(message).toString()
     const consoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined)
@@ -149,8 +152,8 @@ describe('Mailgun email provider', () => {
       vi.fn().mockResolvedValue(
         new Response(
           JSON.stringify({
-            message:
-              'Monthly limit reached for member@rumahberbagi.test at https://kelas.rumahberbagi.test/magic?token=secret-token',
+            message: `Monthly limit reached for ${message.to} at https://kelas.rumahberbagi.test/magic?token=secret-token`,
+            echoedRequestBody,
           }),
           {
             status: 429,
@@ -176,7 +179,9 @@ describe('Mailgun email provider', () => {
     const logOutput = JSON.stringify(consoleError.mock.calls)
     expect(logOutput).toContain('[redacted-url]')
     expect(logOutput).not.toContain('member@rumahberbagi.test')
+    expect(logOutput).not.toContain(encodedRecipient)
     expect(logOutput).not.toContain('secret-token')
+    expect(logOutput).not.toContain(encodedMagicLinkToken)
     expect(logOutput).not.toContain(apiKey)
     expect(logOutput).not.toContain(encodedApiKey)
   })

--- a/app/services/email-provider.server.ts
+++ b/app/services/email-provider.server.ts
@@ -19,6 +19,31 @@ type MailgunMessage = {
   html: string
 }
 
+function sanitizeMailgunResponseBody(body: string) {
+  return body
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[redacted-email]')
+    .replace(/https?:\/\/\S+/gi, '[redacted-url]')
+    .slice(0, 500)
+}
+
+async function getSafeResponseSummary(response: Response) {
+  const contentType = response.headers.get('content-type') ?? 'unknown'
+  let responseBody = ''
+
+  try {
+    responseBody = sanitizeMailgunResponseBody(await response.text())
+  } catch {
+    responseBody = '[unavailable]'
+  }
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    contentType,
+    body: responseBody,
+  }
+}
+
 export async function sendEmail({ to, from, subject, html }: MailgunMessage) {
   const auth = `${Buffer.from(`api:${mailgunSendingKey}`).toString('base64')}`
 
@@ -29,9 +54,6 @@ export async function sendEmail({ to, from, subject, html }: MailgunMessage) {
     html,
   })
 
-  if (process.env.NODE_ENV === 'test') {
-    return Promise.resolve(body)
-  }
   const response = await fetch(
     `https://api.mailgun.net/v3/${mailgunDomain}/messages`,
     {
@@ -42,6 +64,14 @@ export async function sendEmail({ to, from, subject, html }: MailgunMessage) {
       },
     }
   )
+
+  if (!response.ok) {
+    console.error('Mailgun email delivery failed', {
+      response: await getSafeResponseSummary(response),
+    })
+
+    throw new Error(`Mailgun email delivery failed with ${response.status}`)
+  }
 
   return response
 }

--- a/app/services/email-provider.server.ts
+++ b/app/services/email-provider.server.ts
@@ -19,16 +19,18 @@ type MailgunMessage = {
   html: string
 }
 
+function bestEffortDecodeUrlEncodedText(body: string) {
+  return body.replace(/\+/g, ' ').replace(/(?:%[0-9a-fA-F]{2})+/g, (part) => {
+    try {
+      return decodeURIComponent(part)
+    } catch {
+      return part
+    }
+  })
+}
+
 function sanitizeMailgunResponseBody(body: string) {
-  let decodedBody = body
-
-  try {
-    decodedBody = decodeURIComponent(body.replace(/\+/g, ' '))
-  } catch {
-    // Keep the raw body if Mailgun returns malformed percent encoding.
-  }
-
-  return decodedBody
+  return bestEffortDecodeUrlEncodedText(body)
     .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[redacted-email]')
     .replace(/https?:\/\/\S+/gi, '[redacted-url]')
     .replace(/\b(token|secret)=([^&\s"'<>]+)/gi, '$1=[redacted]')

--- a/app/services/email-provider.server.ts
+++ b/app/services/email-provider.server.ts
@@ -20,9 +20,18 @@ type MailgunMessage = {
 }
 
 function sanitizeMailgunResponseBody(body: string) {
-  return body
+  let decodedBody = body
+
+  try {
+    decodedBody = decodeURIComponent(body.replace(/\+/g, ' '))
+  } catch {
+    // Keep the raw body if Mailgun returns malformed percent encoding.
+  }
+
+  return decodedBody
     .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[redacted-email]')
     .replace(/https?:\/\/\S+/gi, '[redacted-url]')
+    .replace(/\b(token|secret)=([^&\s"'<>]+)/gi, '$1=[redacted]')
     .slice(0, 500)
 }
 


### PR DESCRIPTION
## Summary
- check Mailgun responses and throw on non-2xx delivery failures
- log sanitized Mailgun failure context without request payloads, recipient addresses, magic links, or API keys
- cover successful responses, failed responses, and URL-encoded provider echoes in tests

Closes #258

## Verification
- npm test
- npm run type-check
- npx eslint app/services/email-provider.server.ts app/services/__tests__/email.server.test.ts
- npx prettier --check app/services/email-provider.server.ts app/services/__tests__/email.server.test.ts

No deploy performed.