### PR TITLE
fix(auth): rate limit magic link sends

### DIFF
--- a/app/routes/__tests__/login.test.tsx
+++ b/app/routes/__tests__/login.test.tsx
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { action, loader } from '../login'
 import { auth } from '~/services/auth.server'
 import * as emailProvider from '~/services/email-provider.server'
+import {
+  enforceMagicLinkRateLimit,
+  MAGIC_LINK_RATE_LIMIT_MESSAGE,
+} from '~/services/magic-link-rate-limit.server'
 
 vi.mock('~/services/auth.server', () => ({
   auth: {
@@ -9,6 +13,12 @@ vi.mock('~/services/auth.server', () => ({
     isAuthenticated: vi.fn(),
     sessionErrorKey: 'auth:error',
   },
+}))
+
+vi.mock('~/services/magic-link-rate-limit.server', () => ({
+  enforceMagicLinkRateLimit: vi.fn(),
+  MAGIC_LINK_RATE_LIMIT_MESSAGE:
+    'Terlalu banyak permintaan link login. Silakan coba lagi nanti.',
 }))
 
 function getSetCookie(response: Response) {
@@ -53,7 +63,9 @@ function postLogin({ cookie, nonce }: { cookie?: string; nonce?: string }) {
 describe('login route nonce', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    vi.clearAllMocks()
     vi.mocked(auth.isAuthenticated).mockResolvedValue(null as never)
+    vi.mocked(enforceMagicLinkRateLimit).mockResolvedValue(undefined)
   })
 
   it('blocks direct POSTs without a nonce before email authentication can send Mailgun email', async () => {
@@ -90,6 +102,12 @@ describe('login route nonce', () => {
 
   it('allows a browser POST with the session-backed nonce to request a magic link', async () => {
     const { cookie, nonce } = await loadLogin()
+    vi.mocked(enforceMagicLinkRateLimit).mockImplementation(async (request) => {
+      const form = await request.formData()
+
+      expect(form.get('email')).toBe('user@rumahberbagi.test')
+      expect(form.get('loginNonce')).toBe(nonce)
+    })
     vi.mocked(auth.authenticate).mockImplementation(
       async (_strategy, request) => {
         const body = await (request as Request).text()
@@ -103,6 +121,7 @@ describe('login route nonce', () => {
 
     await postLogin({ cookie, nonce })
 
+    expect(enforceMagicLinkRateLimit).toHaveBeenCalledOnce()
     expect(auth.authenticate).toHaveBeenCalledOnce()
     expect(auth.authenticate).toHaveBeenCalledWith(
       'email-link',
@@ -112,5 +131,24 @@ describe('login route nonce', () => {
         failureRedirect: '/login?redirectTo=%2Fdashboard',
       }
     )
+  })
+
+  it('blocks a nonce-valid POST when rate limited before email authentication can send Mailgun email', async () => {
+    const sendEmail = vi.spyOn(emailProvider, 'sendEmail')
+    const { cookie, nonce } = await loadLogin()
+    vi.mocked(enforceMagicLinkRateLimit).mockRejectedValue(
+      new Error(MAGIC_LINK_RATE_LIMIT_MESSAGE)
+    )
+
+    const response = (await postLogin({ cookie, nonce })) as Response
+
+    expect(response).toBeInstanceOf(Response)
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')).toBe(
+      '/login?redirectTo=%2Fdashboard'
+    )
+    expect(enforceMagicLinkRateLimit).toHaveBeenCalledOnce()
+    expect(auth.authenticate).not.toHaveBeenCalled()
+    expect(sendEmail).not.toHaveBeenCalled()
   })
 })

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -3,6 +3,10 @@ import { json, redirect } from '@remix-run/node'
 import { Form, useLoaderData, useNavigation } from '@remix-run/react'
 import { Alert, ErrorAlert } from '~/components/alerts'
 import { Button } from '~/components/form-elements'
+import {
+  enforceMagicLinkRateLimit,
+  MAGIC_LINK_RATE_LIMIT_MESSAGE,
+} from '~/services/magic-link-rate-limit.server'
 import { auth } from '~/services/auth.server'
 import { commitSession, getUserSession } from '~/services/session.server'
 
@@ -75,10 +79,29 @@ export const action: ActionFunction = async ({ request }) => {
     headers: verifiedRequestHeaders,
   })
 
+  try {
+    await enforceMagicLinkRateLimit(verifiedRequest.clone())
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === MAGIC_LINK_RATE_LIMIT_MESSAGE
+    ) {
+      session.flash(auth.sessionErrorKey, { message: error.message })
+
+      return redirect(failureRedirect, {
+        headers: {
+          'Set-Cookie': await commitSession(session),
+        },
+      })
+    }
+
+    throw error
+  }
+
   // The success redirect is required in this action, this is where the user is
   // going to be redirected after the magic link is sent, note that here the
   // user is not yet authenticated, so you can't send it to a private page.
-  await auth.authenticate('email-link', verifiedRequest, {
+  return await auth.authenticate('email-link', verifiedRequest, {
     successRedirect: failureRedirect,
     // If this is not set, any error will be throw and the ErrorBoundary will be
     // rendered.

--- a/app/services/__tests__/magic-link-rate-limit.server.test.ts
+++ b/app/services/__tests__/magic-link-rate-limit.server.test.ts
@@ -54,9 +54,9 @@ describe('enforceMagicLinkRateLimit', () => {
 
   it('allows the boundary attempt before email and IP limits are reached', async () => {
     count
-      .mockResolvedValueOnce(2)
-      .mockResolvedValueOnce(9)
-      .mockResolvedValueOnce(19)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(10)
+      .mockResolvedValueOnce(20)
 
     await enforceMagicLinkRateLimit(
       createRequest('member@rumahberbagi.test', '203.0.113.10'),
@@ -66,8 +66,8 @@ describe('enforceMagicLinkRateLimit', () => {
     expect(create).toHaveBeenCalledTimes(2)
   })
 
-  it('blocks an email after three requests in the short window', async () => {
-    count.mockResolvedValueOnce(3)
+  it('blocks an email after three previous requests in the short window', async () => {
+    count.mockResolvedValueOnce(4)
 
     await expect(
       enforceMagicLinkRateLimit(
@@ -76,14 +76,27 @@ describe('enforceMagicLinkRateLimit', () => {
       )
     ).rejects.toThrow(MAGIC_LINK_RATE_LIMIT_MESSAGE)
 
-    expect(create).not.toHaveBeenCalled()
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  it('blocks an email after ten previous requests in the daily window', async () => {
+    count.mockResolvedValueOnce(1).mockResolvedValueOnce(11)
+
+    await expect(
+      enforceMagicLinkRateLimit(
+        createRequest('member@rumahberbagi.test', '203.0.113.10'),
+        now
+      )
+    ).rejects.toThrow(MAGIC_LINK_RATE_LIMIT_MESSAGE)
+
+    expect(create).toHaveBeenCalledTimes(2)
   })
 
   it('blocks an obvious IP burst after twenty requests in the short window', async () => {
     count
-      .mockResolvedValueOnce(0)
-      .mockResolvedValueOnce(0)
-      .mockResolvedValueOnce(20)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(21)
 
     await expect(
       enforceMagicLinkRateLimit(
@@ -92,19 +105,68 @@ describe('enforceMagicLinkRateLimit', () => {
       )
     ).rejects.toThrow(MAGIC_LINK_RATE_LIMIT_MESSAGE)
 
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses x-real-ip when x-forwarded-for is absent', async () => {
+    count.mockResolvedValue(0)
+
+    await enforceMagicLinkRateLimit(
+      createRequest('member@rumahberbagi.test', undefined, '198.51.100.20'),
+      now
+    )
+
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        entityId: 'ip:198.51.100.20',
+        ipAddress: '198.51.100.20',
+      }),
+    })
+  })
+
+  it('does not record invalid email requests that will not send email', async () => {
+    await enforceMagicLinkRateLimit(createRequest('not-an-email'), now)
+
+    expect(transaction).not.toHaveBeenCalled()
     expect(create).not.toHaveBeenCalled()
+  })
+
+  it('does not record burner email requests that will not send email', async () => {
+    await enforceMagicLinkRateLimit(createRequest('user@example.com'), now)
+
+    expect(transaction).not.toHaveBeenCalled()
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('excludes requests exactly at the window cutoff', async () => {
+    count.mockResolvedValue(0)
+
+    await enforceMagicLinkRateLimit(
+      createRequest('member@rumahberbagi.test', '203.0.113.10'),
+      now
+    )
+
+    expect(count).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        entityId: 'email:member@rumahberbagi.test',
+        createdAt: { gt: new Date('2026-07-02T09:45:00.000Z') },
+      }),
+    })
   })
 })
 
-function createRequest(email: string, ip: string) {
+function createRequest(email: string, forwardedIp?: string, realIp?: string) {
   const form = new URLSearchParams({ email })
+  const headers = new Headers({
+    'content-type': 'application/x-www-form-urlencoded',
+  })
+
+  if (forwardedIp) headers.set('x-forwarded-for', `${forwardedIp}, 10.0.0.1`)
+  if (realIp) headers.set('x-real-ip', realIp)
 
   return new Request('http://localhost:3000/login', {
     method: 'POST',
-    headers: {
-      'content-type': 'application/x-www-form-urlencoded',
-      'x-forwarded-for': `${ip}, 10.0.0.1`,
-    },
+    headers,
     body: form,
   })
 }

--- a/app/services/__tests__/magic-link-rate-limit.server.test.ts
+++ b/app/services/__tests__/magic-link-rate-limit.server.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { count, create, transaction } = vi.hoisted(() => ({
+  count: vi.fn(),
+  create: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+vi.mock('~/utils/db.server', () => ({
+  db: {
+    $transaction: transaction,
+  },
+}))
+
+import {
+  enforceMagicLinkRateLimit,
+  MAGIC_LINK_RATE_LIMIT_MESSAGE,
+} from '../magic-link-rate-limit.server'
+
+describe('enforceMagicLinkRateLimit', () => {
+  const now = new Date('2026-07-02T10:00:00.000Z')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    transaction.mockImplementation((callback) =>
+      callback({ auditLog: { count, create } })
+    )
+    create.mockResolvedValue({})
+  })
+
+  it('allows an occasional magic-link request and records email and IP scopes', async () => {
+    count.mockResolvedValue(0)
+
+    await enforceMagicLinkRateLimit(
+      createRequest('User@RumahBerbagi.test', '203.0.113.10'),
+      now
+    )
+
+    expect(create).toHaveBeenCalledTimes(2)
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        entityId: 'email:user@rumahberbagi.test',
+        createdAt: now,
+        metadata: JSON.stringify({ email: 'user@rumahberbagi.test' }),
+        ipAddress: '203.0.113.10',
+      }),
+    })
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        entityId: 'ip:203.0.113.10',
+      }),
+    })
+  })
+
+  it('allows the boundary attempt before email and IP limits are reached', async () => {
+    count
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(9)
+      .mockResolvedValueOnce(19)
+
+    await enforceMagicLinkRateLimit(
+      createRequest('member@rumahberbagi.test', '203.0.113.10'),
+      now
+    )
+
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  it('blocks an email after three requests in the short window', async () => {
+    count.mockResolvedValueOnce(3)
+
+    await expect(
+      enforceMagicLinkRateLimit(
+        createRequest('member@rumahberbagi.test', '203.0.113.10'),
+        now
+      )
+    ).rejects.toThrow(MAGIC_LINK_RATE_LIMIT_MESSAGE)
+
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('blocks an obvious IP burst after twenty requests in the short window', async () => {
+    count
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(20)
+
+    await expect(
+      enforceMagicLinkRateLimit(
+        createRequest('other@rumahberbagi.test', '203.0.113.10'),
+        now
+      )
+    ).rejects.toThrow(MAGIC_LINK_RATE_LIMIT_MESSAGE)
+
+    expect(create).not.toHaveBeenCalled()
+  })
+})
+
+function createRequest(email: string, ip: string) {
+  const form = new URLSearchParams({ email })
+
+  return new Request('http://localhost:3000/login', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      'x-forwarded-for': `${ip}, 10.0.0.1`,
+    },
+    body: form,
+  })
+}

--- a/app/services/magic-link-rate-limit.server.ts
+++ b/app/services/magic-link-rate-limit.server.ts
@@ -1,0 +1,103 @@
+import { db } from '~/utils/db.server'
+import { generateId } from '~/utils/nanoid'
+
+const RATE_LIMIT_ACTION = 'MAGIC_LINK_EMAIL_REQUESTED'
+const RATE_LIMIT_ENTITY_TYPE = 'MagicLinkRateLimit'
+
+const EMAIL_SHORT_WINDOW_LIMIT = 3
+const EMAIL_SHORT_WINDOW_MS = 15 * 60 * 1000
+const EMAIL_DAILY_LIMIT = 10
+const EMAIL_DAILY_WINDOW_MS = 24 * 60 * 60 * 1000
+const IP_SHORT_WINDOW_LIMIT = 20
+const IP_SHORT_WINDOW_MS = 15 * 60 * 1000
+
+export const MAGIC_LINK_RATE_LIMIT_MESSAGE =
+  'Terlalu banyak permintaan link login. Silakan coba lagi nanti.'
+
+type RateLimitScope = {
+  entityId: string
+  limit: number
+  windowMs: number
+}
+
+export async function enforceMagicLinkRateLimit(
+  request: Request,
+  now = new Date()
+) {
+  const form = await request.formData()
+  const email = form.get('email')
+
+  if (typeof email !== 'string') return
+
+  const normalizedEmail = email.trim().toLowerCase()
+  if (!normalizedEmail) return
+
+  const scopes: RateLimitScope[] = [
+    {
+      entityId: `email:${normalizedEmail}`,
+      limit: EMAIL_SHORT_WINDOW_LIMIT,
+      windowMs: EMAIL_SHORT_WINDOW_MS,
+    },
+    {
+      entityId: `email:${normalizedEmail}`,
+      limit: EMAIL_DAILY_LIMIT,
+      windowMs: EMAIL_DAILY_WINDOW_MS,
+    },
+  ]
+
+  const clientIp = getClientIp(request)
+  if (clientIp) {
+    scopes.push({
+      entityId: `ip:${clientIp}`,
+      limit: IP_SHORT_WINDOW_LIMIT,
+      windowMs: IP_SHORT_WINDOW_MS,
+    })
+  }
+
+  const blocked = await db.$transaction(async (tx) => {
+    for (const scope of scopes) {
+      const count = await tx.auditLog.count({
+        where: {
+          action: RATE_LIMIT_ACTION,
+          entityType: RATE_LIMIT_ENTITY_TYPE,
+          entityId: scope.entityId,
+          createdAt: { gte: new Date(now.getTime() - scope.windowMs) },
+        },
+      })
+
+      if (count >= scope.limit) return true
+    }
+
+    const entityIds = Array.from(new Set(scopes.map((scope) => scope.entityId)))
+
+    await Promise.all(
+      entityIds.map((entityId) =>
+        tx.auditLog.create({
+          data: {
+            id: generateId(),
+            action: RATE_LIMIT_ACTION,
+            entityType: RATE_LIMIT_ENTITY_TYPE,
+            entityId,
+            createdAt: now,
+            metadata: JSON.stringify({ email: normalizedEmail }),
+            ipAddress: clientIp,
+          },
+        })
+      )
+    )
+
+    return false
+  })
+
+  if (blocked) {
+    throw new Error(MAGIC_LINK_RATE_LIMIT_MESSAGE)
+  }
+}
+
+function getClientIp(request: Request) {
+  const forwardedFor = request.headers.get('x-forwarded-for')
+  const firstForwardedIp = forwardedFor?.split(',')[0]?.trim()
+  if (firstForwardedIp) return firstForwardedIp
+
+  return request.headers.get('x-real-ip')?.trim() || undefined
+}

--- a/app/services/magic-link-rate-limit.server.ts
+++ b/app/services/magic-link-rate-limit.server.ts
@@ -1,5 +1,6 @@
 import { db } from '~/utils/db.server'
 import { generateId } from '~/utils/nanoid'
+import { verifyEmailAddress } from '~/services/verifier.server'
 
 const RATE_LIMIT_ACTION = 'MAGIC_LINK_EMAIL_REQUESTED'
 const RATE_LIMIT_ENTITY_TYPE = 'MagicLinkRateLimit'
@@ -20,6 +21,8 @@ type RateLimitScope = {
   windowMs: number
 }
 
+class RateLimitExceeded extends Error {}
+
 export async function enforceMagicLinkRateLimit(
   request: Request,
   now = new Date()
@@ -31,6 +34,12 @@ export async function enforceMagicLinkRateLimit(
 
   const normalizedEmail = email.trim().toLowerCase()
   if (!normalizedEmail) return
+
+  try {
+    await verifyEmailAddress(email)
+  } catch {
+    return
+  }
 
   const scopes: RateLimitScope[] = [
     {
@@ -54,43 +63,47 @@ export async function enforceMagicLinkRateLimit(
     })
   }
 
-  const blocked = await db.$transaction(async (tx) => {
-    for (const scope of scopes) {
-      const count = await tx.auditLog.count({
-        where: {
-          action: RATE_LIMIT_ACTION,
-          entityType: RATE_LIMIT_ENTITY_TYPE,
-          entityId: scope.entityId,
-          createdAt: { gte: new Date(now.getTime() - scope.windowMs) },
-        },
-      })
+  try {
+    await db.$transaction(async (tx) => {
+      const entityIds = Array.from(
+        new Set(scopes.map((scope) => scope.entityId))
+      )
 
-      if (count >= scope.limit) return true
-    }
+      await Promise.all(
+        entityIds.map((entityId) =>
+          tx.auditLog.create({
+            data: {
+              id: generateId(),
+              action: RATE_LIMIT_ACTION,
+              entityType: RATE_LIMIT_ENTITY_TYPE,
+              entityId,
+              createdAt: now,
+              metadata: JSON.stringify({ email: normalizedEmail }),
+              ipAddress: clientIp,
+            },
+          })
+        )
+      )
 
-    const entityIds = Array.from(new Set(scopes.map((scope) => scope.entityId)))
-
-    await Promise.all(
-      entityIds.map((entityId) =>
-        tx.auditLog.create({
-          data: {
-            id: generateId(),
+      for (const scope of scopes) {
+        const count = await tx.auditLog.count({
+          where: {
             action: RATE_LIMIT_ACTION,
             entityType: RATE_LIMIT_ENTITY_TYPE,
-            entityId,
-            createdAt: now,
-            metadata: JSON.stringify({ email: normalizedEmail }),
-            ipAddress: clientIp,
+            entityId: scope.entityId,
+            createdAt: { gt: new Date(now.getTime() - scope.windowMs) },
           },
         })
-      )
-    )
 
-    return false
-  })
+        if (count > scope.limit) throw new RateLimitExceeded()
+      }
+    })
+  } catch (error) {
+    if (error instanceof RateLimitExceeded) {
+      throw new Error(MAGIC_LINK_RATE_LIMIT_MESSAGE)
+    }
 
-  if (blocked) {
-    throw new Error(MAGIC_LINK_RATE_LIMIT_MESSAGE)
+    throw error
   }
 }
 


### PR DESCRIPTION
## Summary
- add a durable AuditLog-backed magic-link send rate limiter before Mailgun sends
- limit by normalized email (3/15 min and 10/day) and best-available IP (20/15 min)
- avoid counting invalid/burner emails, use reservation-then-count transaction semantics, and show the existing login error alert when blocked

Fixes #257

## Verification
- npm test
- npm run type-check
- npm run lint