### PR TITLE
ci: limit e2e test runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
     name: End-to-end test
     if: github.repository == 'zainfathoni/kelas.rumahberbagi.com'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: cache-npm
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Closes <!-- no issue -->

## Description

Adds a 5-minute timeout to the CI End-to-end test job so Playwright install/test hangs stop burning ~30+ minutes of runner time.

Context: recent PRs had E2E jobs cancelled after ~33–35 minutes while stuck during Playwright browser installation, before tests ran.

## Verification

- Parsed .github/workflows/ci.yml as YAML
- Ran git diff --check