### PR TITLE
fix(auth): disable production magic link emails

### DIFF
--- a/app/services/__tests__/email.server.test.ts
+++ b/app/services/__tests__/email.server.test.ts
@@ -70,6 +70,23 @@ describe('sendEmail', () => {
     )
   })
 
+  it('disables delivery without logging the magic link', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    process.env.MAGIC_LINK_EMAIL_DELIVERY = 'disabled'
+    const sendSpy = vi.spyOn(emailProvider, 'sendEmail')
+    const infoSpy = vi
+      .spyOn(console, 'info')
+      .mockImplementation(() => undefined)
+
+    await sendMagicLink()
+
+    expect(sendSpy).not.toHaveBeenCalled()
+    expect(infoSpy).toHaveBeenCalledWith(
+      '🔶 Magic link email delivery disabled'
+    )
+    expect(JSON.stringify(infoSpy.mock.calls)).not.toContain(magicLink)
+  })
+
   it('throws when the delivery mode is unsupported', async () => {
     process.env.MAGIC_LINK_EMAIL_DELIVERY = 'noop'
     const sendSpy = vi.spyOn(emailProvider, 'sendEmail')

--- a/app/services/email.server.tsx
+++ b/app/services/email.server.tsx
@@ -13,7 +13,7 @@ if (process.env.EMAIL_FROM) {
 function getMagicLinkEmailDelivery() {
   const delivery = process.env.MAGIC_LINK_EMAIL_DELIVERY ?? 'mailgun'
 
-  if (delivery !== 'mailgun' && delivery !== 'log') {
+  if (delivery !== 'mailgun' && delivery !== 'log' && delivery !== 'disabled') {
     throw new Error(`Unsupported MAGIC_LINK_EMAIL_DELIVERY: ${delivery}`)
   }
 
@@ -82,6 +82,11 @@ export const sendEmail: SendEmailFunction<User> = async (options) => {
   // unchanged.
   if (getMagicLinkEmailDelivery() === 'log') {
     console.info('🔶 Magic link email delivery disabled:', options.magicLink)
+    return
+  }
+
+  if (getMagicLinkEmailDelivery() === 'disabled') {
+    console.info('🔶 Magic link email delivery disabled')
     return
   }
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -39,6 +39,7 @@ env:
     NODE_ENV: production
     PORT: "3000"
     DATABASE_URL: file:/app/prisma/prod.db
+    MAGIC_LINK_EMAIL_DELIVERY: disabled
   # Secret environment variables (loaded from .kamal/secrets)
   secret:
     - SESSION_SECRET


### PR DESCRIPTION
## Summary

- add a production-safe disabled magic-link email delivery mode
- prevent Mailgun calls without logging email addresses or magic-link tokens
- explicitly disable magic-link email delivery in production deployment config

## Verification

- `npm test` (145 tests)
- `npm run type-check`
- `npx eslint app/services/email.server.tsx app/services/__tests__/email.server.test.ts config/deploy.yml`
- `npm run build`